### PR TITLE
AB2D-6109 TIBQ: ab2d-sample-client-powershell

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ Example in powershell:
 If you only want claims data updated or filed before a certain date specify the `$UNTIL` parameter.
 The expected format is yyyy-MM-dd'T'HH:mm:ss.SSSXXX+/-ZZ:ZZ which follows ISO datetime standards.
 
-For requests using FHIR R4, a default `_until` value is supplied if one is not provided. The value of the default `_until`
-parameter is set to the current date and time.
+This parameter is only available with V2 (FHIR R4). 
+If no `_until` date is specified or you use a date from the future, it will default to the current date and time.
 
 Examples:
 1. March 1, 2024 at 3 PM EST -> `2024-03-01T15:00:00.000-05:00`

--- a/README.md
+++ b/README.md
@@ -57,6 +57,24 @@ Example in powershell:
    $SINCE=2020-03-01T15:00:00.000-05:00
    ```
 
+## UNTIL
+
+If you only want claims data updated or filed before a certain date specify the `$UNTIL` parameter.
+The expected format is yyyy-MM-dd'T'HH:mm:ss.SSSXXX+/-ZZ:ZZ which follows ISO datetime standards.
+
+For requests using FHIR R4, a default `_until` value is supplied if one is not provided. The value of the default `_until`
+parameter is set to the current date and time.
+
+Examples:
+1. March 1, 2024 at 3 PM EST -> `2024-03-01T15:00:00.000-05:00`
+2. May 31, 2024 at 4 AM PST `2024-05-31T04:00:00-08:00`
+
+Example in powershell:
+
+   ```ShellSession
+   $UNTIL=2024-03-01T15:00:00.000-05:00
+   ```
+
 ## Step-by-Step Guide
 
 1. Note the following
@@ -158,6 +176,9 @@ Example in powershell:
    
    # If you only want claims data updated or filed after a specific date use the $SINCE parameter
    $SINCE=2020-02-13T00:00:00.000-05:00
+   
+   # If you only want claims data updated or filed before a specific date use the $UNTIL parameter
+   $UNTIL=2024-02-13T00:00:00.000-05:00
    ```
 
    *Production FHIR R4 (replace {variable} with your settings, for FHIR STU3, replace v2 with v1 in `AB2D_API_URL`):*
@@ -169,6 +190,9 @@ Example in powershell:
    
    # If you only want claims data updated or filed after a specific date use the $SINCE parameter
    $SINCE=2020-02-13T00:00:00.000-05:00
+      
+   # If you only want claims data updated or filed before a specific date use the $UNTIL parameter
+   $UNTIL=2024-02-13T00:00:00.000-05:00
    ```
    
 1. Create an export job

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Examples:
 Example in powershell:
 
    ```ShellSession
-   $SINCE=2020-03-01T15:00:00.000-05:00
+   $SINCE='2020-03-01T15:00:00.000-05:00'
    ```
 
 ## UNTIL
@@ -72,7 +72,7 @@ Examples:
 Example in powershell:
 
    ```ShellSession
-   $UNTIL=2024-03-01T15:00:00.000-05:00
+   $UNTIL='2024-03-01T15:00:00.000-05:00'
    ```
 
 ## Step-by-Step Guide
@@ -175,10 +175,10 @@ Example in powershell:
    $AB2D_API_URL='https://sandbox.ab2d.cms.gov/api/v2'
    
    # If you only want claims data updated or filed after a specific date use the $SINCE parameter
-   $SINCE=2020-02-13T00:00:00.000-05:00
+   $SINCE='2020-02-13T00:00:00.000-05:00'
    
    # If you only want claims data updated or filed before a specific date use the $UNTIL parameter
-   $UNTIL=2024-02-13T00:00:00.000-05:00
+   $UNTIL='2024-02-13T00:00:00.000-05:00'
    ```
 
    *Production FHIR R4 (replace {variable} with your settings, for FHIR STU3, replace v2 with v1 in `AB2D_API_URL`):*
@@ -189,10 +189,10 @@ Example in powershell:
    $AB2D_API_URL='https://api.ab2d.cms.gov/api/v2'
    
    # If you only want claims data updated or filed after a specific date use the $SINCE parameter
-   $SINCE=2020-02-13T00:00:00.000-05:00
+   $SINCE='2020-02-13T00:00:00.000-05:00'
       
    # If you only want claims data updated or filed before a specific date use the $UNTIL parameter
-   $UNTIL=2024-02-13T00:00:00.000-05:00
+   $UNTIL='2024-02-13T00:00:00.000-05:00'
    ```
    
 1. Create an export job

--- a/create-job.ps1
+++ b/create-job.ps1
@@ -8,6 +8,12 @@ if (-NOT (TEST-PATH -PATH $AUTH_FILE))
     exit
 }
 
+if ($AB2D_API_URL -like "*/v1" -And $UNTIL)
+{
+    Write-Host 'The _until parameter is only available with version 2 (FHIR R4) of the API'
+    exit
+}
+
 $AUTH = Get-Content $AUTH_FILE
 $AUTH = $AUTH.Trim()
 
@@ -33,6 +39,11 @@ if ($SINCE)
 {
     $SINCE = $SINCE -replace ":", "%3A"
     $EXPORT_URL = $EXPORT_URL + "&_since=" + $SINCE
+}
+if ($UNTIL)
+{
+    $UNTIL = $UNTIL -replace ":", "%3A"
+    $EXPORT_URL = $EXPORT_URL + "&_until=" + $UNTIL
 }
 
 Write-Host '---------------------------------------------------------------------------------------------------------------------'


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-6109

## 🛠 Changes

Added _until parameter to create-job.ps1

## ℹ️ Context

Currently, AB2D API only accepts _since as a date parameter. The goal is for AB2D to be able to support the use case where a PDP could run jobs with time interval based queries so that they could download their data in batches. To achieve that, we will add a _until parameter to define the upper ceiling of the date range.

Both the since and _until parameter will be applied to the lastupdated_Date.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

<img width="1122" alt="Screenshot 2024-07-26 at 1 46 59 PM" src="https://github.com/user-attachments/assets/2d9fcb0d-4e95-41d6-84ae-d8e4ebd1a807">

