### PR TITLE
AB2D-6945 Update sample clients to support v3 API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This may be a great starting point for your engineering or development teams how
 
 Use of these clients in the sandbox environment allows for safe testing and ensures no PII/PHI will not be compromised if a mistake is made. The sandbox environment is publicly available and all the data in it is synthetic (**not** real)
 
-AB2D supports both R4 and STU3 versions of the FHIR standard. FHIR R4 is available using v2 of AB2D while FHIR STU3 can be accessed via AB2D v1. Accordingly, this client supports both R4/v2 and STU3/v1.
+AB2D supports both R4 and STU3 versions of the FHIR standard. FHIR R4 is available using v2 and v3 of AB2D while FHIR STU3 can be accessed via AB2D v1. Accordingly, this client supports both R4/v2 and STU3/v1.
 
 ## Production Use Disclaimer:
 

--- a/create-job.ps1
+++ b/create-job.ps1
@@ -2,6 +2,36 @@
 # create-job.ps1
 ###################################
 
+# Validate FHIR version and AB2D endpoint version
+if (-not $env:FHIR_VERSION) {
+    Write-Host "The FHIR version must be specified in FHIR_VERSION environment variable [R4 | STU3]"
+    exit
+}
+
+$FHIR_VERSION = $env:FHIR_VERSION
+$AB2D_ENDPOINT = $env:AB2D_ENDPOINT  # optional
+
+if ($FHIR_VERSION -ne "R4" -and $FHIR_VERSION -ne "STU3") {
+    Write-Host "The FHIR version must be either R4 or STU3 (current: $FHIR_VERSION)"
+    exit
+}
+
+if ($FHIR_VERSION -eq "STU3" -and $AB2D_ENDPOINT) {
+    Write-Host "The --ab2d-endpoint parameter (AB2D_ENDPOINT) is only available with FHIR R4"
+    exit
+}
+
+if ($FHIR_VERSION -eq "R4") {
+    if (-not $AB2D_ENDPOINT) {
+        $AB2D_ENDPOINT = "v2"
+        Write-Host "AB2D_ENDPOINT was not set; defaulting to v2 for FHIR R4"
+    }
+    elseif ($AB2D_ENDPOINT -ne "v2" -and $AB2D_ENDPOINT -ne "v3") {
+        Write-Host "When using FHIR R4, AB2D_ENDPOINT must be one of: v2 or v3 (current: $AB2D_ENDPOINT)"
+        exit
+    }
+}
+
 if (-NOT (TEST-PATH -PATH $AUTH_FILE))
 {
     Write-Host 'Auth credentials file does not exist or this program does not have permission to access it'


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-6945

## 🛠 Changes

Added parameter for the AB2D API version.

## ℹ️ Context

Currently the user only provides the --fhir parameter (STU3 or R4).
For the v3 update, we need a new parameter to distinguish between v2 and v3 when the user selects R4.

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
